### PR TITLE
Utilisation de stream et apache commons dans Tokenizer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,26 @@
             <version>1.0.0-alpha1</version>
         </dependency>
 
+        <!-- Apache commons -->
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.16.1</version>
+        </dependency>
+
         <!-- postgresql -->
 
         <dependency>

--- a/src/main/java/com/example/myapp/tokenizer/TokenizerMyAppImpl.java
+++ b/src/main/java/com/example/myapp/tokenizer/TokenizerMyAppImpl.java
@@ -1,12 +1,12 @@
 package com.example.myapp.tokenizer;
-
 import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.model.Tokenizer;
+import org.apache.commons.collections4.IterableUtils;
 import org.springframework.stereotype.Component;
-
+import java.util.stream.StreamSupport;
 
 @Component
 public class TokenizerMyAppImpl implements Tokenizer {
@@ -41,35 +41,29 @@ public class TokenizerMyAppImpl implements Tokenizer {
 
     @Override
     public int estimateTokenCountInTools(Iterable<Object> objectsWithTools) {
-        int total = 0;
-        if (objectsWithTools != null) {
-            for (Object obj : objectsWithTools) {
-                total += estimateTokenCountInTools(obj);
-            }
-        }
-        return total;
+        return StreamSupport.stream(
+                        IterableUtils.emptyIfNull(objectsWithTools).spliterator(),
+                        true)
+                .mapToInt(this::estimateTokenCountInTools)
+                .sum();
     }
 
     @Override
     public int estimateTokenCountInToolSpecifications(Iterable<ToolSpecification> toolSpecifications) {
-        int total = 0;
-        if (toolSpecifications != null) {
-            for (ToolSpecification spec : toolSpecifications) {
-                total += estimateTokenCountInText(spec.toString());
-            }
-        }
-        return total;
+        return StreamSupport.stream(
+                        IterableUtils.emptyIfNull(toolSpecifications).spliterator(),
+                        true)
+                .mapToInt(spec -> estimateTokenCountInText(spec.toString()))
+                .sum();
     }
 
     @Override
     public int estimateTokenCountInToolExecutionRequests(Iterable<ToolExecutionRequest> toolExecutionRequests) {
-        int total = 0;
-        if (toolExecutionRequests != null) {
-            for (ToolExecutionRequest req : toolExecutionRequests) {
-                total += estimateTokenCountInText(req.toString());
-            }
-        }
-        return total;
+        return StreamSupport.stream(
+                        IterableUtils.emptyIfNull(toolExecutionRequests).spliterator(),
+                        true)
+                .mapToInt(req -> estimateTokenCountInText(req.toString()))
+                .sum();
     }
 
     @Override


### PR DESCRIPTION
les boucles 'for' dans l'implémentation de Tokenizer sont remplacées par l'utilisation des streams, et utilisation de la bibliothèque Apache Commons.